### PR TITLE
Add API server endpoint to collect status events from clusters

### DIFF
--- a/huxley-api/src/api.coffee
+++ b/huxley-api/src/api.coffee
@@ -28,6 +28,21 @@ builder.define "users",
   as: "create"
   creates: "user"
 
+builder.define "deployments",
+  path: "/deployments"
+.post
+  as: "create"
+  creates: "deployment"
+
+builder.define "deployment",
+  template: "/deployment/:deployment_id"
+.get()
+.delete()
+
+builder.define "status",
+  template: "/deployment/:deployment_id/status"
+.post
+  creates: "status"
 
 builder.reflect()
 console.log builder.api

--- a/huxley-api/src/handlers.coffee
+++ b/huxley-api/src/handlers.coffee
@@ -241,12 +241,15 @@ module.exports = async ->
 
   status:
     post: async ({respond, data}) ->
-      {deployment_id, cluster} = status = yield data
+      {deployment_id, cluster, application_id} = status = yield data
       deployment = yield deployments.get deployment_id
 
       # create deployment if not exists
       unless deployment?
-        deployment = id: deployment_id, cluster: cluster
+        deployment =
+          id: deployment_id
+          cluster: cluster
+          application_id: application_id
 
       # add status to appropriate queue
       deployment.services ?= {}

--- a/huxley-api/test/index.coffee
+++ b/huxley-api/test/index.coffee
@@ -42,6 +42,7 @@ amen.describe "Huxley API", (context) ->
 
       assert.equal response.id, Status.deployment_id
       assert.equal response.cluster, Status.cluster
+      assert.equal response.application_id, Status.application_id
       assert response.services?
       assert typeof response.services == 'object'
       assert response.services[Status.service] instanceof Array

--- a/huxley-api/test/index.coffee
+++ b/huxley-api/test/index.coffee
@@ -4,22 +4,25 @@ assert = require "assert"
 
 amen.describe "Huxley API", (context) ->
 
-  context.test "Create a user", (context) ->
-
-    api = yield discover "http://localhost:8080"
-
-    {response: {headers: {location}}} =
-      yield api.clusters.create
-        name: "test-cluster"
-        email: "test@pandastrike.com"
-        url: "tipsy-tester"
-
-    cluster = (api.cluster location)
-
-    context.test "Retrieve cluster", ->
-
-      {data} = yield cluster.get()
-      console.log yield data
+  #-------------------------------------------------------
+  # User functionality is commented out in handlers.coffee
+  #-------------------------------------------------------
+  # context.test "Create a user", (context) ->
+  #
+  #   api = yield discover "http://localhost:8080"
+  #
+  #   {response: {headers: {location}}} =
+  #     yield api.clusters.create
+  #       name: "test-cluster"
+  #       email: "test@pandastrike.com"
+  #       url: "tipsy-tester"
+  #
+  #   cluster = (api.cluster location)
+  #
+  #   context.test "Retrieve cluster", ->
+  #
+  #     {data} = yield cluster.get()
+  #     console.log yield data
 
   context.test "Post a status", (context) ->
     Status =

--- a/huxley-api/test/index.coffee
+++ b/huxley-api/test/index.coffee
@@ -20,3 +20,29 @@ amen.describe "Huxley API", (context) ->
 
       {data} = yield cluster.get()
       console.log yield data
+
+  context.test "Post a status", (context) ->
+    Status =
+      cluster: "tipsy-tester"
+      application_id: "abcdef"
+      deployment_id: "deadbeef"
+      service: "node"
+      status: "starting"
+      timestamp: Date.now()
+
+    api = yield discover "http://localhost:8080"
+
+    # deployment does not need to exist, it is created automaticaly
+    {response} = api.status.post Status
+
+    context.test "Retrieve deployment information", ->
+      deployment = api.deployment "deadbeef"
+      {data} = yield deployment.get()
+      response = yield data
+
+      assert.equal response.id, Status.deployment_id
+      assert.equal response.cluster, Status.cluster
+      assert response.services?
+      assert typeof response.services == 'object'
+      assert response.services[Status.service] instanceof Array
+      assert.deepEqual response.services[Status.service].pop(), Status


### PR DESCRIPTION
## Summary

As discussed in #70, this adds an endpoint to the API server to collect status events from clusters. As discussed in #77, the kick server will use this endpoint to submit information about its services starting up or stopping. 
## Status

**This is still in progress. Please do not merge yet**
