### PR TITLE
Feature: Deployment status API

### DIFF
--- a/huxley-api/src/api.coffee
+++ b/huxley-api/src/api.coffee
@@ -33,6 +33,8 @@ builder.define "deployments",
 .post
   as: "create"
   creates: "deployment"
+.get
+  as: "query"
 
 builder.define "deployment",
   template: "/deployment/:deployment_id"
@@ -45,6 +47,5 @@ builder.define "status",
   creates: "status"
 
 builder.reflect()
-console.log builder.api
 
 module.exports = builder.api

--- a/huxley-api/src/api.coffee
+++ b/huxley-api/src/api.coffee
@@ -28,6 +28,21 @@ builder.define "users",
   as: "create"
   creates: "user"
 
+builder.define "deployments",
+  path: "/deployments"
+.post
+  as: "create"
+  creates: "deployment"
+
+builder.define "deployment",
+  template: "/deployment/:deployment_id"
+.get()
+.delete()
+
+builder.define "status",
+  template: "/deployment/:deployment_id/status"
+.post
+  creates: "status"
 
 builder.reflect()
 console.log builder.api

--- a/huxley-api/src/handlers.coffee
+++ b/huxley-api/src/handlers.coffee
@@ -215,11 +215,15 @@ module.exports = async ->
     # NOTE: deployments are created automatically when the first status
     # is POSTed. We include this endpoint for completeness's sake
     create: async ({respond, url, data}) ->
-      {deployment_id, cluster} = yield data
+      {deployment_id, cluster_id} = yield data
       yield deployments.put deployment_id,
         id: deployment_id
-        cluster: cluster
+        cluster_id
       respond 200, "Created", location: url "deployment", {deployment_id}
+
+    query: async ({respond, match: {query}}) ->
+      console.log query
+      respond 200, JSON.stringify yield deployments.all()
 
   deployment:
     get: async ({respond, match: {path: {deployment_id}}}) ->
@@ -244,15 +248,12 @@ module.exports = async ->
 
   status:
     post: async ({respond, data}) ->
-      {deployment_id, cluster, application_id, service} = status = yield data
+      {deployment_id, cluster_id, application_id, service} = status = yield data
       deployment = yield deployments.get deployment_id
 
       # create deployment if not exists
       unless deployment?
-        deployment =
-          id: deployment_id
-          cluster: cluster
-          application_id: application_id
+        deployment = {id: deployment_id, cluster_id, application_id}
 
       # add status to appropriate queue
       deployment.services ?= {}

--- a/huxley-api/src/handlers.coffee
+++ b/huxley-api/src/handlers.coffee
@@ -222,7 +222,7 @@ module.exports = async ->
       respond 200, "Created", location: url "deployment", {deployment_id}
 
     query: async ({respond, match: {query}}) ->
-      console.log query
+      # Workaround for pandastrike/pbx#13
       respond 200, JSON.stringify yield deployments.all()
 
   deployment:

--- a/huxley-api/src/handlers.coffee
+++ b/huxley-api/src/handlers.coffee
@@ -241,12 +241,15 @@ module.exports = async ->
 
   status:
     post: async ({respond, data}) ->
-      {deployment_id, cluster} = status = yield data
+      {deployment_id, cluster, application_id} = status = yield data
       deployment = yield deployments.get deployment_id
 
       # create deployment if not exists
       unless deployment?
-        deployment = id: deployment_id, cluster: cluster
+        deployment =
+          id: deployment_id
+          cluster: cluster
+          application_id: application_id
 
       # add status to appropriate queue
       deployment.services ?= {}

--- a/huxley-api/test/index.coffee
+++ b/huxley-api/test/index.coffee
@@ -27,7 +27,7 @@ amen.describe "Huxley API", (context) ->
 
   context.test "Post a status", (context) ->
     Status =
-      cluster: "tipsy-tester"
+      cluster_id: "tipsy-tester"
       application_id: "abcdef"
       deployment_id: "deadbeef"
       service: "node"
@@ -46,7 +46,7 @@ amen.describe "Huxley API", (context) ->
       response = yield data
 
       assert.equal response.id, Status.deployment_id
-      assert.equal response.cluster, Status.cluster
+      assert.equal response.cluster_id, Status.cluster_id
       assert.equal response.application_id, Status.application_id
       assert response.services?
       assert typeof response.services == 'object'

--- a/huxley-api/test/index.coffee
+++ b/huxley-api/test/index.coffee
@@ -42,6 +42,7 @@ amen.describe "Huxley API", (context) ->
 
       assert.equal response.id, Status.deployment_id
       assert.equal response.cluster, Status.cluster
+      assert.equal response.application_id, Status.application_id
       assert response.services?
       assert typeof response.services == 'object'
       assert response.services[Status.service] instanceof Array

--- a/huxley-api/test/index.coffee
+++ b/huxley-api/test/index.coffee
@@ -1,6 +1,7 @@
 {discover} = (require "pbx").client
 amen = require "amen"
 assert = require "assert"
+{w} = require "fairmont"
 
 amen.describe "Huxley API", (context) ->
 
@@ -31,6 +32,7 @@ amen.describe "Huxley API", (context) ->
       deployment_id: "deadbeef"
       service: "node"
       status: "starting"
+      detail: foo: "bar"
       timestamp: Date.now()
 
     api = yield discover "http://localhost:8080"
@@ -48,5 +50,5 @@ amen.describe "Huxley API", (context) ->
       assert.equal response.application_id, Status.application_id
       assert response.services?
       assert typeof response.services == 'object'
-      assert response.services[Status.service] instanceof Array
-      assert.deepEqual response.services[Status.service].pop(), Status
+      for property in w 'status detail timestamp'
+        assert.deepEqual response.services[Status.service][property], Status[property]

--- a/huxley-api/test/index.coffee
+++ b/huxley-api/test/index.coffee
@@ -4,22 +4,25 @@ assert = require "assert"
 
 amen.describe "Huxley API", (context) ->
 
-  context.test "Create a user", (context) ->
-
-    api = yield discover "http://localhost:8080"
-
-    {response: {headers: {location}}} =
-      yield api.clusters.create
-        name: "test-cluster"
-        email: "test@pandastrike.com"
-        url: "tipsy-tester"
-
-    cluster = (api.cluster location)
-
-    context.test "Retrieve cluster", ->
-
-      {data} = yield cluster.get()
-      console.log yield data
+  #-------------------------------------------------------
+  # User functionality is commented out in handlers.coffee
+  #-------------------------------------------------------
+  # context.test "Create a user", (context) ->
+  #
+  #   api = yield discover "http://localhost:8080"
+  #
+  #   {response: {headers: {location}}} =
+  #     yield api.clusters.create
+  #       name: "test-cluster"
+  #       email: "test@pandastrike.com"
+  #       url: "tipsy-tester"
+  #
+  #   cluster = (api.cluster location)
+  #
+  #   context.test "Retrieve cluster", ->
+  #
+  #     {data} = yield cluster.get()
+  #     console.log yield data
 
   context.test "Post a status", (context) ->
     Status =

--- a/huxley-api/test/index.coffee
+++ b/huxley-api/test/index.coffee
@@ -20,3 +20,29 @@ amen.describe "Huxley API", (context) ->
 
       {data} = yield cluster.get()
       console.log yield data
+
+  context.test "Post a status", (context) ->
+    Status =
+      cluster: "tipsy-tester"
+      application_id: "abcdef"
+      deployment_id: "deadbeef"
+      service: "node"
+      status: "starting"
+      timestamp: Date.now()
+
+    api = yield discover "http://localhost:8080"
+
+    # deployment does not need to exist, it is created automaticaly
+    {response} = api.status.post Status
+
+    context.test "Retrieve deployment information", ->
+      deployment = api.deployment "deadbeef"
+      {data} = yield deployment.get()
+      response = yield data
+
+      assert.equal response.id, Status.deployment_id
+      assert.equal response.cluster, Status.cluster
+      assert response.services?
+      assert typeof response.services == 'object'
+      assert response.services[Status.service] instanceof Array
+      assert.deepEqual response.services[Status.service].pop(), Status


### PR DESCRIPTION
## Summary

As discussed in #70, this adds an endpoint to the API server to collect status events from clusters. As discussed in #77, the kick server will use this endpoint to submit information about its services starting up or stopping. 
## Details

This adds a new resource, `deployment`, and three new paths, with the following actions:

```
/deployments (POST, GET)
/deployment/:id (GET, DELETE)
/status (POST)
```

POSTing to `/deployments` creates a new deployment, and requires a `deployment_id` and a `cluster_id`. 
The GET action lists all deployments known to the system (filtering will be available once https://github.com/pandastrike/pbx/issues/19 has been sorted out).

The `/deployment/:id` path should be relatively self-explanatory. In fact, **we might want to get rid of DELETE because we don't need it, and this should be considered archival information.**

Finally, the `/status` path [accepts status messages from the kick server](https://github.com/pandastrike/panda-kick/pull/8), and adds them to the corresponding deployment. This will go away in a future version when we implement message queueing with Mutual.
